### PR TITLE
Allow reconnects after disconnection

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -80,6 +80,7 @@
         <button data-copy-target="share-link-input">Copy</button>
       </div>
       <button id="cancel-button" hidden>Stop Sharing</button>
+      <button id="reconnect-button" hidden>Reconnect</button>
     </div>
   </main>
   <main id="receive-container" hidden>
@@ -136,6 +137,7 @@
     const receiveContainer = document.getElementById("receive-container");
     const generateButton = document.getElementById("generate-button");
     const cancelButton = document.getElementById("cancel-button");
+    const reconnectButton = document.getElementById("reconnect-button");
     const sendStatusMessage = document.getElementById("send-status-message");
     const receiveStatusMessage = document.getElementById("receive-status-message");
     const textarea = document.getElementById("plaintext");
@@ -259,8 +261,22 @@
       sendStatusMessage.innerText = "Encrypting message..."
       const { cipherBytes, key } = await encrypt(id, payload)
 
+      // Setup the websocket connection
+      const ws = configureRelay(id, cipherBytes, key)
+
+      // When the user closes the tab, confirm they want to stop sharing if the websocket is active
+      window.addEventListener("beforeunload", (event) => {
+        if (ws.readyState === WebSocket.OPEN) {
+          event.preventDefault();
+          event.returnValue = ""; // Browsers will show a default message, no matter what we return
+        }
+      })
+    }
+
+    async function configureRelay(id, cipherBytes, key) {
+      reconnectButton.hidden = true;
       sendStatusMessage.innerText = "Relaying message..."
-      const ws = relayMessage(id, cipherBytes, {
+      return relayMessage(id, cipherBytes, {
         onOpen: (ws) => {
           const url = window.location.origin + `?id=${id}#${key}`
           sendStatusMessage.innerText = 'Waiting for recipients...';
@@ -281,23 +297,18 @@
           resetSendForm()
         },
         onFailure: (event) => {
-          sendStatusMessage.innerText = `Error: ${event.reason || "Disconnected"}`
-          resetSendForm()
+          sendStatusMessage.innerText = `⚠️ Error: ${event.reason || "Disconnected"}`
+          cancelButton.onclick = () => resetSendForm();
+          reconnectButton.hidden = false;
+          reconnectButton.onclick = () => configureRelay(id, cipherBytes, key);
         },
-      })
-
-      // When the user closes the tab, confirm they want to stop sharing if the websocket is active
-      window.addEventListener("beforeunload", (event) => {
-        if (ws.readyState === WebSocket.OPEN) {
-          event.preventDefault();
-          event.returnValue = ""; // Browsers will show a default message, no matter what we return
-        }
       })
     }
 
     function resetSendForm() {
       linkStatusMessage.hidden = true;
       cancelButton.hidden = true;
+      reconnectButton.hidden = true;
       generateButton.disabled = false
       textarea.disabled = false
       fileInput.disabled = false

--- a/public/index.html
+++ b/public/index.html
@@ -35,6 +35,47 @@
       margin: 2rem 0;
     }
 
+    span.indicator {
+      display: inline-block;
+      width: 1rem;
+      height: 1rem;
+      border-radius: 50%;
+      margin-left: 0.5rem;
+    }
+
+    span.indicator.waiting {
+      animation: slow-pulse 2s ease-out infinite;
+      background: currentColor;
+    }
+
+    @keyframes slow-pulse {
+      0% {
+        transform: scale(0);
+        opacity: 1;
+      }
+
+      100% {
+        transform: scale(2);
+        opacity: 0;
+      }
+    }
+
+    span.indicator.loading {
+      animation: spin 1s linear infinite;
+      border: 2px solid;
+      border-color: currentColor transparent;
+    }
+
+    @keyframes spin {
+      0% {
+        transform: rotate(0deg);
+      }
+
+      100% {
+        transform: rotate(360deg);
+      }
+    }
+
   </style>
   <!-- Simple feature detection with nomodule to notify browsers that don't support ES6 -->
   <script>document.documentElement.classList.add('js');</script>
@@ -275,11 +316,11 @@
 
     async function configureRelay(id, cipherBytes, key) {
       reconnectButton.hidden = true;
-      sendStatusMessage.innerText = "Relaying message..."
+      sendStatusMessage.innerHTML = "Connecting to relay... <span class='loading indicator'></span>"
       return relayMessage(id, cipherBytes, {
         onOpen: (ws) => {
           const url = window.location.origin + `?id=${id}#${key}`
-          sendStatusMessage.innerText = 'Waiting for recipients...';
+          sendStatusMessage.innerHTML = 'Waiting for recipients... <span class="waiting indicator"></span>';
           cancelButton.hidden = false;
           cancelButton.onclick = () => ws.close(1000, "DONE");
           shareLink.href = url;
@@ -287,13 +328,13 @@
           linkStatusMessage.hidden = false;
         },
         onPeerReady: () => {
-          sendStatusMessage.innerText = "Connected to recipient, sending file..."
+          sendStatusMessage.innerHTML = "Connected to recipient, sending file... <span class='loading indicator'></span>"
         },
         onPeerReceived: () => {
-          sendStatusMessage.innerText = 'Sent! Waiting for recipients...';
+          sendStatusMessage.innerHTML = 'Sent! 🚀 Waiting for recipients...<span class="waiting indicator"></span> ';
         },
         onFinish: () => {
-          sendStatusMessage.innerText = "Done!"
+          sendStatusMessage.innerHTML = "Done!"
           resetSendForm()
         },
         onFailure: (event) => {


### PR DESCRIPTION
This allows shared links to remain valid, since if the network disconnects for a short period of time, the user can reconnect with the same session ID and key.