### PR TITLE
Update 'Enctypted' to 'Encrypted'

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="UTF-8">
-  <title>Private Passage: Real-time Enctypted Secret Sharing</title>
+  <title>Private Passage: Real-time Encrypted Secret Sharing</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="theme.css">


### PR DESCRIPTION
People might feel safer as enctyption has not been around as long as
encryption so it does not give the same reputational benefit.